### PR TITLE
Fix pytest crashes observed in pytest 8.2.2

### DIFF
--- a/pytest_bug/plugin.py
+++ b/pytest_bug/plugin.py
@@ -238,14 +238,13 @@ class PyTestBug:
                 if report.passed:
                     setattr(report, MARK_BUG, PassBug(mark_bug.comment))
                 elif report.failed:
-                    report.outcome, report.wasxfail = ("skipped", "skipped")
                     setattr(report, MARK_BUG, FailBug(mark_bug.comment))
 
     def pytest_report_teststatus(self, report: TestReport):
         if isinstance(mark_bug := getattr(report, MARK_BUG, None), ReportBug):
             self._counter(mark_bug)
             self.config.hook.pytest_bug_report_teststatus(report=report, report_bug=mark_bug)
-            return report.outcome, mark_bug.letter, (mark_bug.word, mark_bug.markup)
+            return report.outcome, mark_bug.letter, mark_bug.word
 
     def pytest_terminal_summary(self, terminalreporter: TerminalReporter):
         if not self.config.getoption("bug_summary_stats") and self.config.getini("bug_summary_stats"):


### PR DESCRIPTION
This PR fixes the issues reported in #26 and #27.

For #26 - Removing the line fixes the issue, but I would feel better about this particular workaround if I understood why that line was there in the first place.  I know it's been a while, but do you recall what the purpose was?

For #27 - Replacing the tuple with a simple string gets around the issue with no negative side effects.  I'm still inclined to think that we need a proper fix in pytest because the existing code should be correct per the documentation.


@tolstislon - what are your thoughts?